### PR TITLE
Issue #22 Use loremipsum endpoint to generate the random text

### DIFF
--- a/site/js/geopatterns-demo.js
+++ b/site/js/geopatterns-demo.js
@@ -3,7 +3,7 @@
 
 // API handled by AWS Lambda
 const API_URL = 'https://dqrura49d0.execute-api.us-east-1.amazonaws.com/generate';
-const RANDOM_TEXT_URL = 'https://fish-text.ru/get?format=json&number=1';
+const RANDOM_TEXT_URL = 'https://dqrura49d0.execute-api.us-east-1.amazonaws.com/random-phrase';
 
 
 function random_int(max) {


### PR DESCRIPTION
Closes #22 
I changed the request url, but unfortunately I can't test the correctness of the js. An endpoint API access error is bothering me:

romanzorkin.github.io/:1 Access to XMLHttpRequest at 'https://dqrura49d0.execute-api.us-east-1.amazonaws.com/random-phrase' from origin 'https://romanzorkin.github.io' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.

'axios' module in 'mounted' method of 'GeopatternsApp' const have response construction: .then(response => (this.text = response.data.text)); this response is actual for json model - https://fish-text.ru/get?format=json&number=1'. Our json model is similar. I hope everything will work correctly